### PR TITLE
feat: standardize responses from server

### DIFF
--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -9,6 +9,7 @@
 typedef struct ccask_db ccask_db;
 typedef struct ccask_get_result ccask_get_result;
 typedef struct ccask_result ccask_result;
+typedef enum response_type response_type;
 
 // ccask_db functions
 
@@ -30,12 +31,12 @@ uint8_t* ccask_gr_val(uint8_t* dest, const ccask_get_result* src);
 void ccask_gr_destroy(ccask_get_result* gr);
 void ccask_gr_delete(ccask_get_result* gr);
 void ccask_gr_print(ccask_get_result* gr);
-int ccask_gr_bytes(ccask_get_result* gr, uint8_t* buf, size_t buflen);
-int ccask_res_bytes(ccask_result* res, uint8_t* buf, size_t buflen);
+uint32_t ccask_gr_bytes(ccask_get_result* gr, uint8_t* buf, size_t buflen);
+uint32_t ccask_res_bytes(ccask_result* res, uint8_t* buf, size_t buflen);
 
 // query interp
-ccask_result* ccask_res_init(ccask_result* res, uint8_t type);
-ccask_result* ccask_res_new(uint8_t type);
+ccask_result* ccask_res_init(ccask_result* res, response_type type);
+ccask_result* ccask_res_new(response_type type);
 void ccask_res_destroy(ccask_result* res);
 void ccask_res_delete(ccask_result* res);
 void ccask_res_print(ccask_result* res);

--- a/src/ccask_server.c
+++ b/src/ccask_server.c
@@ -300,6 +300,8 @@ int ccask_server_run(ccask_server* srv) {
 					if (send(sender_fd, buf, rv, 0) == -1) {
 						perror("send");
 					}
+
+					if (res != 0) ccask_res_delete(res);
 				}
 			}
 		}


### PR DESCRIPTION
Responses to SET and GET commands issued to the server are now standardized per [issue 2](https://github.com/tydar/ccask/issues/2).