### PR TITLE
feat: implement ccask_config

### DIFF
--- a/src/ccask_config.c
+++ b/src/ccask_config.c
@@ -1,0 +1,178 @@
+#include "ccask_config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define DEFAULT_PORT "29456"
+#define DEFAULT_KDSIZE 1024
+#define DEFAULT_MAXCONN 5
+#define DEFAULT_MAXMSG 1024
+#define DEFAULT_IPV UNSPEC
+
+char* ipv_string(ccask_ip_v ipv) {
+    switch(ipv) {
+    case INET4:
+        return "INET4";
+    case INET6:
+        return "INET6";
+    case UNSPEC:
+        return "UNSPEC";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+struct ccask_config {
+    char* port;
+    size_t keydir_size;
+    size_t maxconn;
+    size_t max_msg_size;
+    ccask_ip_v ipv;
+};
+
+char* PORT = "CCASK_PORT";
+char* KDSIZE = "CCASK_KDSIZE";
+char* MAXCONN = "CCASK_MAXCONN";
+char* MAXMSG = "CCASK_MAX_MSG_SIZE";
+char* IPV = "CCASK_IPV";
+
+ccask_config* ccask_config_init(ccask_config* cf, char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size,
+                                ccask_ip_v ipv) {
+    if (cf) {
+        *cf = (ccask_config) {
+            .port = malloc(strlen(port)),
+            .keydir_size = keydir_size,
+            .maxconn = maxconn,
+            .max_msg_size = max_msg_size,
+            .ipv = ipv
+        };
+
+        if (cf->port) {
+            strcpy(cf->port, port);
+        } else {
+            *cf = (ccask_config) {
+                0
+            };
+        }
+    } else {
+        *cf = (ccask_config) {
+            0
+        };
+    }
+
+    return cf;
+}
+
+ccask_config* ccask_config_new(char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size, ccask_ip_v ipv) {
+    ccask_config* cf = malloc(sizeof(ccask_config));
+    if (!cf) return 0;
+    cf = ccask_config_init(cf, port, keydir_size, maxconn, max_msg_size, ipv);
+    return cf;
+}
+
+/**@brief ccask_config_from_env creates a new config struct from environment variable parsing & defaults*/
+ccask_config* ccask_config_from_env() {
+    char* port_str = getenv(PORT);
+    char* kdsize_str = getenv(KDSIZE);
+    char* maxconn_str = getenv(MAXCONN);
+    char* maxmsg_str = getenv(MAXMSG);
+    char* ipv_str = getenv(IPV);
+
+
+    char* port = 0;
+    if (!port_str) {
+        fprintf(stderr, "config: using default port %s\n", DEFAULT_PORT);
+        port = DEFAULT_PORT;
+    } else {
+        port = port_str;
+    }
+
+    size_t kdsize = DEFAULT_KDSIZE;
+    if (kdsize_str) {
+        kdsize = strtoull(kdsize_str, NULL, 10);
+        if (kdsize == 0)  {
+            fprintf(stderr, "config: CCASK_KDSIZE env value %s invalid; using default %ul\n", kdsize_str, DEFAULT_KDSIZE);
+            kdsize = DEFAULT_KDSIZE;
+        }
+    }
+
+    size_t maxconn = DEFAULT_MAXCONN;
+    if (maxconn_str) {
+        maxconn = strtoull(maxconn_str, NULL, 10);
+        if (maxconn == 0) {
+            fprintf(stderr, "config: CCASK_MAXCONN env value %s invalid; using default %ul\n", maxconn_str, DEFAULT_MAXCONN);
+            maxconn = DEFAULT_MAXCONN;
+        }
+    }
+
+    size_t maxmsg = DEFAULT_MAXMSG;
+    if (maxmsg_str) {
+        maxmsg = strtoull(maxmsg_str, NULL, 10);
+        if (maxmsg == 0) {
+            fprintf(stderr, "config: CCASK_MAXMSG env value %s invalid; using default %ul\n", maxmsg_str, DEFAULT_MAXMSG);
+            maxmsg = DEFAULT_MAXMSG;
+        }
+    }
+
+    ccask_ip_v ipv = DEFAULT_IPV;
+    if (ipv_str) {
+        if (strcmp(ipv_str, "INET4") == 0) {
+            ipv = INET4;
+        } else if (strcmp(ipv_str, "INET6") == 0) {
+            ipv = INET6;
+        } else if (strcmp(ipv_str, "UNSPEC") == 0) {
+            ipv = UNSPEC;
+        } else {
+            fprintf(stderr, "config: CCASK_IPV env value %s unrecognized; using default %s\n", ipv_str, ipv_string(DEFAULT_IPV));
+        }
+    }
+
+    return ccask_config_new(port, kdsize, maxconn, maxmsg, ipv);
+}
+
+void ccask_config_destroy(ccask_config* cf) {
+    if(cf) {
+        free(cf->port);
+        *cf = (ccask_config) {
+            0
+        };
+    }
+}
+
+void ccask_config_delete(ccask_config* cf) {
+    ccask_config_destroy(cf);
+    free(cf);
+}
+
+void ccask_config_print(ccask_config* cf) {
+    printf("port: %s\tkeydir size: %zu\tmax connection count: %zu\nmax message size: %zu B\tIP type: %s\n",
+           cf->port,
+           cf->keydir_size,
+           cf->maxconn,
+           cf->max_msg_size,
+           ipv_string(cf->ipv));
+}
+
+int ccask_config_port(char* dest, ccask_config* src, size_t destlen) {
+    size_t len = strlen(src->port);
+    if (destlen < len || !dest) return -1;
+
+    strcpy(dest, src->port);
+    return len;
+}
+
+size_t ccask_config_kdsize(ccask_config* src) {
+    return src->keydir_size;
+}
+
+size_t ccask_config_maxconn(ccask_config* src) {
+    return src->maxconn;
+}
+
+size_t ccask_config_maxmsg(ccask_config* src) {
+    return src->max_msg_size;
+}
+
+ccask_ip_v ccask_config_ipv(ccask_config* src) {
+    return src->ipv;
+}

--- a/src/ccask_config.h
+++ b/src/ccask_config.h
@@ -1,0 +1,31 @@
+#ifndef _CONFIG_H
+#define _CONFIG_H
+
+#include <stddef.h>
+
+enum ccask_ip_v {
+    INET4,
+    INET6,
+    UNSPEC
+};
+
+typedef struct ccask_config ccask_config;
+typedef enum ccask_ip_v ccask_ip_v;
+
+ccask_config* ccask_config_init(ccask_config* cf, char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size,
+                                ccask_ip_v ipv);
+ccask_config* ccask_config_new(char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size, ccask_ip_v ipv);
+ccask_config* ccask_config_from_env();
+
+void ccask_config_delete(ccask_config* cf);
+void ccask_config_destroy(ccask_config* cf);
+
+void ccask_config_print(ccask_config* cf);
+
+int ccask_config_port(char* dest, ccask_config* src, size_t destlen);
+size_t ccask_config_kdsize(ccask_config* src);
+size_t ccask_config_maxconn(ccask_config* src);
+size_t ccask_config_maxmsg(ccask_config* src);
+ccask_ip_v ccask_config_ipv(ccask_config* src);
+
+#endif

--- a/src/ccask_db.c
+++ b/src/ccask_db.c
@@ -16,9 +16,6 @@
  * @brief ccask_db.c implements useful DB operations (get, set, populate from file)
  */
 
-// TODO: make KEYDIR_SIZE configurable or at least think harder about a sensible value
-#define KEYDIR_SIZE 1024
-
 // TODO: change commands to an enum
 #define GET_CMD 0
 #define SET_CMD 1
@@ -244,13 +241,13 @@ ccask_db* ccask_db_populate(ccask_db* db) {
     return db;
 }
 
-ccask_db* ccask_db_init(ccask_db* db, const char* path) {
+ccask_db* ccask_db_init(ccask_db* db, const char* path, ccask_config* cfg) {
     if (db && path) {
         *db = (ccask_db) {
             .path = malloc(strlen(path)),
             .file_pos = 0,
             .file_id = 0,
-            .keydir = ccask_keydir_new(KEYDIR_SIZE),
+            .keydir = ccask_keydir_new(ccask_config_kdsize(cfg)),
             .file = 0,
         };
 
@@ -280,9 +277,9 @@ ccask_db* ccask_db_init(ccask_db* db, const char* path) {
     return db;
 }
 
-ccask_db* ccask_db_new(const char* path) {
+ccask_db* ccask_db_new(const char* path, ccask_config* cfg) {
     ccask_db* db = malloc(sizeof(ccask_db));
-    db = ccask_db_init(db, path);
+    db = ccask_db_init(db, path, cfg);
     return db;
 }
 

--- a/src/ccask_db.c
+++ b/src/ccask_db.c
@@ -24,13 +24,6 @@
 #define SET_CMD 1
 
 // Response formats
-enum response_type {
-    GET_SUCCESS,
-    GET_FAIL,
-    SET_SUCCESS,
-    SET_FAIL,
-    BAD_COMMAND
-};
 
 // struct defs
 

--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 
 #include "ccask_kv.h"
+#include "ccask_config.h"
 
 enum response_type {
     GET_SUCCESS,
@@ -22,8 +23,8 @@ typedef enum response_type response_type;
 // ccask_db functions
 
 // initializer / destructors
-ccask_db* ccask_db_init(ccask_db* db, const char* path);
-ccask_db* ccask_db_new(const char* path);
+ccask_db* ccask_db_init(ccask_db* db, const char* path, ccask_config* cfg);
+ccask_db* ccask_db_new(const char* path, ccask_config* cfg);
 void ccask_db_destroy(ccask_db* db);
 void ccask_db_delete(ccask_db* db);
 

--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -6,6 +6,14 @@
 
 #include "ccask_kv.h"
 
+enum response_type {
+    GET_SUCCESS,
+    GET_FAIL,
+    SET_SUCCESS,
+    SET_FAIL,
+    BAD_COMMAND
+};
+
 typedef struct ccask_db ccask_db;
 typedef struct ccask_get_result ccask_get_result;
 typedef struct ccask_result ccask_result;

--- a/src/ccask_server.h
+++ b/src/ccask_server.h
@@ -1,13 +1,14 @@
 #ifndef _CCASK_SERVER_H
 #define _CCASK_SERVER_H
 
+#include "ccask_config.h"
 #include "ccask_db.h"
 
 typedef struct ccask_server ccask_server;
 
 // init / destroy
-ccask_server* ccask_server_init(ccask_server* srv, char* port, ccask_db* db);
-ccask_server* ccask_server_new(char* port, ccask_db* db);
+ccask_server* ccask_server_init(ccask_server* srv, ccask_db* db, ccask_config* cfg);
+ccask_server* ccask_server_new(ccask_db* db, ccask_config* cfg);
 
 void ccask_server_destroy(ccask_server* srv);
 void ccask_server_delete(ccask_server* srv);

--- a/src/main.c
+++ b/src/main.c
@@ -6,12 +6,13 @@
 #include "ccask_keydir.h"
 #include "ccask_db.h"
 #include "ccask_server.h"
+#include "ccask_config.h"
 
 int main(void) {
     crc_init();
-
     ccask_db* db = ccask_db_new("./ccask_file");
 
+	/*	
     uint8_t key[5] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
     uint8_t value[10] = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
 
@@ -43,8 +44,15 @@ int main(void) {
     res = ccask_db_get(db, 5, key3);
     ccask_gr_print(res);
     ccask_gr_delete(res);
+	*/
+	
 
-    ccask_server* srv = ccask_server_new("29456", db);
+	ccask_config* cfg = ccask_config_from_env();
+	if (!cfg) {
+		fprintf(stderr, "ccask: failure to configure\n");
+		return 1;
+	}
+    ccask_server* srv = ccask_server_new(db, cfg);
     ccask_server_run(srv);
 
     ccask_db_delete(db);

--- a/src/main.c
+++ b/src/main.c
@@ -9,15 +9,21 @@
 #include "ccask_config.h"
 
 int main(void) {
-    crc_init();
-    ccask_db* db = ccask_db_new("./ccask_file");
+    ccask_config* cfg = ccask_config_from_env();
+    if (!cfg) {
+        fprintf(stderr, "ccask: failure to configure\n");
+        return 1;
+    }
 
-	/*	
+    crc_init();
+    ccask_db* db = ccask_db_new("./ccask_file", cfg);
+
+    /*
     uint8_t key[5] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
-    uint8_t value[10] = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+    uint8_t value[10] = { 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41 };
 
     uint8_t key2[5] = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE };
-    uint8_t value2[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    uint8_t value2[10] = { 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42, 0x42 };
 
     db = ccask_db_set(db, 5, key, 10, value);
     db = ccask_db_set(db, 5, key2, 10, value2);
@@ -44,14 +50,8 @@ int main(void) {
     res = ccask_db_get(db, 5, key3);
     ccask_gr_print(res);
     ccask_gr_delete(res);
-	*/
-	
+    */
 
-	ccask_config* cfg = ccask_config_from_env();
-	if (!cfg) {
-		fprintf(stderr, "ccask: failure to configure\n");
-		return 1;
-	}
     ccask_server* srv = ccask_server_new(db, cfg);
     ccask_server_run(srv);
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -118,8 +118,9 @@ void test_keydir(void) {
 
 void test_db(void) {
     puts("\t===== ccask_db tests ======");
+	ccask_config* cfg = ccask_config_from_env();
 
-    ccask_db* db = ccask_db_new("TEST_DB_FILE");
+    ccask_db* db = ccask_db_new("TEST_DB_FILE", cfg);
     puts("Assert DB ptr not null after _new...");
     assert(db != 0);
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200112L
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -11,6 +13,7 @@
 #include "ccask_kv.h"
 #include "ccask_keydir.h"
 #include "ccask_db.h"
+#include "ccask_config.h"
 #include "util.h"
 
 void test_kdrow(void) {
@@ -204,7 +207,7 @@ void test_db(void) {
     res = 0;
     res = ccask_query_interp(db, cmd);
     assert(res != 0);
-    assert(ccask_res_type(res) == 1);
+    assert(ccask_res_type(res) == SET_SUCCESS);
     puts("query type set accurate");
 
     cmdsz = 4 + 1 + 4 + 4 + 5;
@@ -223,7 +226,7 @@ void test_db(void) {
     ccask_res_delete(res);
     res = 0;
     res = ccask_query_interp(db, cmd);
-    assert(ccask_res_type(res) == 0);
+    assert(ccask_res_type(res) == GET_SUCCESS);
     puts("query interp succeeds");
 
     res_vsz = ccask_res_vsz(res);
@@ -289,6 +292,42 @@ void test_util(void) {
     puts("\t===== done =====");
 }
 
+void test_config(void) {
+    puts("\t===== test ccask_config =====");
+    int yes_replace = 1;
+
+    char* env_port = "8001";
+    assert(setenv("CCASK_PORT", env_port, yes_replace) == 0);
+
+    char* env_kdsize = "2048";
+    assert(setenv("CCASK_KDSIZE", env_kdsize, yes_replace) == 0);
+
+    char* env_maxconn = "10";
+    assert(setenv("CCASK_MAXCONN", env_maxconn, yes_replace) == 0);
+
+    char* env_maxmsg = "2048";
+    assert(setenv("CCASK_MAX_MSG_SIZE", env_maxmsg, yes_replace) == 0);
+
+    char* env_ipv = "INET4";
+    assert(setenv("CCASK_IPV", env_ipv, yes_replace) == 0);
+
+    ccask_config* cfg = ccask_config_from_env();
+    puts("config created from env successfully");
+
+    char* dest = malloc(strlen(env_port));
+    int rv = ccask_config_port(dest, cfg, strlen(env_port));
+    assert(rv == strlen(env_port));
+    assert(strcmp(dest, env_port) == 0);
+
+    assert(ccask_config_kdsize(cfg) == 2048);
+    assert(ccask_config_maxconn(cfg) == 10);
+    assert(ccask_config_maxmsg(cfg) == 2048);
+    assert(ccask_config_ipv(cfg) == INET4);
+    puts("config object populated as expected");
+
+    puts("\t===== done =====");
+}
+
 int main(void) {
     test_kdrow();
     puts("");
@@ -297,4 +336,6 @@ int main(void) {
     test_util();
     puts("");
     test_db();
+    puts("");
+    test_config();
 }


### PR DESCRIPTION
Allow setting configuration values via environment variables and provide
sensible defaults. Expose enum values from ccask_db and ccask_config for
testing. Implement ccask_config tests and fix some ccask_db tests.

Still TODO: integrate ccask_config into server startup procedure & use configured values throughout ccask.