### PR TITLE
feat: implement multi-file support

### DIFF
--- a/src/ccask_db.c
+++ b/src/ccask_db.c
@@ -416,6 +416,11 @@ void ccask_db_newfile(ccask_db* db) {
     free(new_filename);
 }
 
+size_t ccask_db_fid(const ccask_db* db) {
+    if(!db) return SIZE_MAX;
+    return db->file_id;
+}
+
 /**
  * set implementation
  * 1) calc crc

--- a/src/ccask_db.c
+++ b/src/ccask_db.c
@@ -11,6 +11,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 /**@file
  * @brief ccask_db.c implements useful DB operations (get, set, populate from file)
@@ -25,11 +28,13 @@
 // struct defs
 
 struct ccask_db {
-    ccask_keydir* keydir; // The keydir structure for this ccask instance
-    size_t file_pos;      // Cursor pos in the file
+    ccask_keydir* keydir;   // The keydir structure for this ccask instance
+    size_t file_pos;        // Cursor pos in the file
     size_t file_id;
-    char* path;           // Path to the DB file
-    FILE* file;           // Pointer to the file we are writing
+    char* path;             // Path to the DB file
+    FILE* file;             // Pointer to the file we are writing
+    DIR* dir;               // Pointer to the DB file dir
+    FILE* files[MAX_FILES]; // collection of all files in this ccask
 };
 
 struct ccask_get_result {
@@ -161,8 +166,10 @@ uint32_t ccask_gr_bytes(ccask_get_result* gr, uint8_t* buf, size_t buflen) {
 // used to populate the keydir when the software starts iff a ccask file is present
 
 /**@brief internal fn to populate next keydir entry*/
-ccask_db* ccask_db_popnext(ccask_db* db) {
-    FILE* file = db->file;
+ccask_db* ccask_db_popnext(ccask_db* db, int index) {
+    FILE* file = db->files[index];
+    if (!file) return 0;
+
     size_t pos = ftell(file);
     uint8_t* hdrb = malloc(HEADER_BYTES);
     size_t hdr_n = fread(hdrb, 1, HEADER_BYTES, file);
@@ -203,7 +210,8 @@ ccask_db* ccask_db_popnext(ccask_db* db) {
     key = ccask_kv_key(key, kv);
 
     // TODO: file ID
-    ccask_kdrow* kdr = ccask_kdrow_new(ksz, key, 0, vsz, pos, time(NULL));
+    ccask_kdrow* kdr = ccask_kdrow_new(ksz, key, index, vsz, pos, time(NULL));
+    ccask_kdrow_print(kdr);
     if (!ccask_keydir_insert(db->keydir, kdr)) {
         free(key);
         free(hdrb);
@@ -229,18 +237,50 @@ ccask_db* ccask_db_popnext(ccask_db* db) {
 /**@brief given a malloc'd and initialized db and a valid file populates the keydir*/
 ccask_db* ccask_db_populate(ccask_db* db) {
     if (!db) return 0;
-    ccask_db* iter = ccask_db_popnext(db);
 
-    while(iter) {
-        iter = ccask_db_popnext(db);
+    errno = 0;
+    struct dirent* pDirent;
+
+    for (pDirent = readdir(db->dir); pDirent; pDirent = readdir(db->dir)) {
+        if (strcmp(".", pDirent->d_name) == 0 || strcmp("..", pDirent->d_name) == 0) continue;
+
+        // we will treat every file in the directory as if it were a ccask file
+        // TODO: introduce magic number or other file ID method
+        size_t pathlen = strlen(db->path) + strlen(pDirent->d_name) + 1 + 1; // path len + filename len + / + \0
+        char* path = malloc(pathlen);
+        printf("file ID: %zu file name: %s\n", db->file_id, pDirent->d_name);
+
+        path = strcpy(path, db->path);
+        path = strcat(path, "/");
+        path = strncat(path, pDirent->d_name, strlen(pDirent->d_name));
+        if (!path) return 0;
+
+        FILE *f = fopen(path, "rb");
+        if (!f) {
+            fprintf(stderr, "fopen(%s,...)\n", path);
+            perror("fopen");
+            exit(1);
+        }
+
+        db->files[db->file_id] = f;
+        db->file_id++;
     }
 
-    if (fseek(db->file, 0, SEEK_SET) == -1) {
-        perror("seek error");
-        errno = 0;
+    if (errno != 0) {
+        perror("readdir");
+        exit(1);
     }
 
-    db->file_pos = ftell(db->file);
+
+    for (size_t i = 0; i < MAX_FILES; i++) {
+        if (!db->files[i]) break;
+
+        ccask_db* iter = ccask_db_popnext(db, i);
+
+        while(iter) {
+            iter = ccask_db_popnext(db, i);
+        }
+    }
 
     return db;
 }
@@ -253,25 +293,58 @@ ccask_db* ccask_db_init(ccask_db* db, const char* path, ccask_config* cfg) {
             .file_id = 0,
             .keydir = ccask_keydir_new(ccask_config_kdsize(cfg)),
             .file = 0,
+            .dir = 0,
+            .files = { 0 },
         };
 
-        //TODO: check errors on fopen
         db->path = strncpy(db->path, path, strlen(path));
+        DIR* dir = opendir(path);
+        if (dir == 0) {
+            // we were unable to open the dir
+            if (errno == ENOENT && strcmp(db->path, "") != 0) {
+                // directory does not exist, try to create it
+                errno = 0;
+                int res = mkdir(path, 0700);
+                if (res == -1) {
+                    perror("mkdir");
+                    exit(1);
+                }
 
-        //TODO: allow restarting the ccask process without clobbering the current file
-        FILE* f = fopen(path, "ab+");
-
-        if (!f) {
-            perror("fopen");
-            errno = 0;
-        } else {
-            // if the file existed with content we want to rewind to the start
-            if (ftell(f) != 0) fseek(f, 0, SEEK_SET);
-            db->file = f;
-            if (!ccask_db_populate(db)) *db = (ccask_db) {
-                0
-            };
+                dir = opendir(path);
+                if (dir == 0) {
+                    perror("opendir");
+                    exit(1);
+                }
+            } else {
+                perror("opendir");
+                exit(1);
+            }
         }
+
+        db->dir = dir;
+        if (!ccask_db_populate(db)) *db = (ccask_db) {
+            0
+        };
+
+        char* new_filename = malloc(strlen(path) + 1 + strlen(path) + MAX_FILE_CHARS);
+        int res = snprintf(new_filename, strlen(path) + strlen(path) + 1 + MAX_FILE_CHARS, "%s/%s_%zu", path, path, db->file_id);
+        if (res < 0) {
+            fprintf(stderr, "error constructing new filename\n");
+            exit(1);
+        }
+
+        errno = 0;
+        FILE* new_file = fopen(new_filename, "w+b");
+        if (!new_file) {
+            fprintf(stderr, "%s\n", new_filename);
+            perror("fopen");
+            exit(1);
+        }
+
+        printf("new file %s open for writing\n", new_filename);
+
+        db->file = new_file;
+        db->files[db->file_id] = new_file;
     } else {
         *db = (ccask_db) {
             0
@@ -471,16 +544,42 @@ ccask_get_result* ccask_db_get(ccask_db* db, uint32_t key_size, uint8_t* key) {
         return 0;
     }
 
-    if (fseek(db->file, value_pos, SEEK_SET) == -1) {
+    FILE* file = db->files[file_id];
+
+    if (fseek(file, value_pos, SEEK_SET) != 0) {
         perror("seek error");
         errno = 0;
         return 0;
     }
 
-    size_t row_size = HEADER_SIZE + value_size + key_size;
+    size_t row_size = HEADER_BYTES + value_size + key_size;
 
     uint8_t* row_ptr = malloc(row_size);
-    size_t read_size = fread(row_ptr, row_size, 1, db->file);
+    size_t read_size = fread(row_ptr, row_size, 1, file);
+
+    if (read_size < 1) {
+        printf("read size: %zu\n", read_size);
+        for (size_t i = 0; i < read_size*row_size; i++) {
+            printf("0x%.02x ", row_ptr[i]);
+        }
+        puts("");
+        free(row_ptr);
+
+        int ferr = ferror(file);
+        printf("ferror: %d\n", ferr);
+
+        if(ferr) perror("fread");
+
+        int fe = feof(file);
+        printf("feof: %d\n", fe);
+
+        int ft = ftell(file);
+        printf("ftell: %d\n", ft);
+
+        printf("file_id: %u\n", file_id);
+
+        return 0;
+    }
 
     ccask_header* hdr = ccask_header_new(0, 0, 0, 0);
     if (!ccask_header_deserialize(hdr, row_ptr)) {
@@ -504,6 +603,8 @@ ccask_get_result* ccask_db_get(ccask_db* db, uint32_t key_size, uint8_t* key) {
 
     bool crc_flag = crc_check(hdr, kv);
     ccask_get_result* gr = ccask_gr_new(value_size, value, crc_flag);
+
+    ccask_gr_print(gr);
 
     ccask_kv_delete(kv);
     ccask_header_delete(hdr);

--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -10,7 +10,11 @@
 #define MAX_FILES 256
 #define MAX_FILE_CHARS 4 // number of digits in MAX_FILES + 1 for \0
 #define CCASK_MAGIC_NUMBER 0x0CCA2CFF
+
+// if we are compiling tests, we want to have a small max-file-size for easier testing
+// #define MAX_FILE_BYTES 1024
 #define MAX_FILE_BYTES 512*(1024)*(1024) // 512 MB
+
 
 enum response_type {
     GET_SUCCESS,
@@ -36,6 +40,9 @@ void ccask_db_delete(ccask_db* db);
 // get / set
 ccask_db* ccask_db_set(ccask_db* db, uint32_t key_size, uint8_t* key, uint32_t value_size, uint8_t* value);
 ccask_get_result* ccask_db_get(ccask_db* db, uint32_t key_size, uint8_t* key);
+
+// getters
+size_t ccask_db_fid(const ccask_db* db);
 
 // ccask_get_result functions
 ccask_get_result* ccask_gr_init(ccask_get_result* gr, uint32_t value_size, uint8_t* value, bool crc_passed);

--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -10,6 +10,7 @@
 #define MAX_FILES 256
 #define MAX_FILE_CHARS 4 // number of digits in MAX_FILES + 1 for \0
 #define CCASK_MAGIC_NUMBER 0x0CCA2CFF
+#define MAX_FILE_BYTES 512*(1024)*(1024) // 512 MB
 
 enum response_type {
     GET_SUCCESS,

--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -7,6 +7,10 @@
 #include "ccask_kv.h"
 #include "ccask_config.h"
 
+#define MAX_FILES 256
+#define MAX_FILE_CHARS 4 // number of digits in MAX_FILES + 1 for \0
+#define CCASK_MAGIC_NUMBER 0x0CCA2CFF
+
 enum response_type {
     GET_SUCCESS,
     GET_FAIL,

--- a/src/ccask_keydir.c
+++ b/src/ccask_keydir.c
@@ -157,7 +157,7 @@ size_t ccask_kdrow_vpos(ccask_kdrow* kdr) {
 }
 
 void ccask_kdrow_print(ccask_kdrow* kdr) {
-    printf("Key size: %u Value pos: %zu Value size: %u ", kdr->key_size, kdr->value_pos, kdr->value_size);
+    printf("File ID: %u Key size: %u Value pos: %zu Value size: %u ", kdr->file_id, kdr->key_size, kdr->value_pos, kdr->value_size);
     printf("Key: [ ");
     for (uint32_t i = 0; i < kdr->key_size; i++) {
         printf("%hhx ", kdr->key[i]);

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -241,6 +241,30 @@ void test_db(void) {
     assert(memcmp(val2, res_val, vsz) == 0);
     puts("query get result accurate value");
 
+    printf("test file-to-file transition. max file size: %d\n", MAX_FILE_BYTES);
+    size_t fid_before = ccask_db_fid(db);
+    uint8_t k1[8], k2[8];
+    uint8_t v1[512], v2[512];
+    for (size_t i = 0; i < 8; i++) {
+        k1[i] = 0x42 + i;
+        k2[7-i] = 0x42 + i;
+    }
+
+    for (size_t i = 0; i < 512; i++) {
+        v1[i] = (i % 26) + 0x42;
+        v2[511-i] = (i % 26) + 0x42;
+    }
+
+    db = ccask_db_set(db, 8, k1, 512, v1);
+    assert(db != 0);
+
+    db = ccask_db_set(db, 8, k2, 512, v2);
+    assert(db != 0);
+
+    size_t fid_after = ccask_db_fid(db);
+    puts("Asserting fid has been advanced...");
+    assert(fid_before != fid_after);
+
     ccask_db_delete(db);
     ccask_gr_delete(gr);
     ccask_res_delete(res);

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -120,7 +120,7 @@ void test_db(void) {
     puts("\t===== ccask_db tests ======");
     ccask_config* cfg = ccask_config_from_env();
 
-    ccask_db* db = ccask_db_new("TEST_DB_FILE", cfg);
+    ccask_db* db = ccask_db_new("TEST_DB_DIR", cfg);
     puts("Assert DB ptr not null after _new...");
     assert(db != 0);
 
@@ -128,7 +128,7 @@ void test_db(void) {
     uint8_t key[5] = { 1, 2, 3, 4, 5 };
 
     uint32_t vsz = 5;
-    uint8_t val[5] = { 5, 4, 3, 2, 1 };
+    uint8_t val[5] = { 0x42, 0x42, 0x42, 0x42, 0x42 };
     db = ccask_db_set(db, ksz, key, vsz, val);
     puts("Assert DB not null after set....");
     assert(db != 0);


### PR DESCRIPTION
Modify DB intialization, get, and set procedures to support multiple DB files. Start a new file in the ccask file directory with each restart of CCask.

Implements #14 