### PR TITLE
enable dynamic keydir resizing

### DIFF
--- a/src/ccask_config.h
+++ b/src/ccask_config.h
@@ -13,8 +13,9 @@ typedef struct ccask_config ccask_config;
 typedef enum ccask_ip_v ccask_ip_v;
 
 ccask_config* ccask_config_init(ccask_config* cf, char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size,
-                                ccask_ip_v ipv);
-ccask_config* ccask_config_new(char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size, ccask_ip_v ipv);
+                                ccask_ip_v ipv, size_t keydir_max_size);
+ccask_config* ccask_config_new(char* port, size_t keydir_size, size_t maxconn, size_t max_msg_size, ccask_ip_v ipv,
+                               size_t keydir_max_size);
 ccask_config* ccask_config_from_env();
 
 void ccask_config_delete(ccask_config* cf);
@@ -23,9 +24,10 @@ void ccask_config_destroy(ccask_config* cf);
 void ccask_config_print(ccask_config* cf);
 
 int ccask_config_port(char* dest, ccask_config* src, size_t destlen);
-size_t ccask_config_kdsize(ccask_config* src);
-size_t ccask_config_maxconn(ccask_config* src);
-size_t ccask_config_maxmsg(ccask_config* src);
-ccask_ip_v ccask_config_ipv(ccask_config* src);
+size_t ccask_config_kdsize(const ccask_config* src);
+size_t ccask_config_maxconn(const ccask_config* src);
+size_t ccask_config_maxmsg(const ccask_config* src);
+ccask_ip_v ccask_config_ipv(const ccask_config* src);
+size_t ccask_config_kdmax(const ccask_config* src);
 
 #endif

--- a/src/ccask_db.c
+++ b/src/ccask_db.c
@@ -297,7 +297,7 @@ ccask_db* ccask_db_init(ccask_db* db, const char* path, ccask_config* cfg) {
             .file_pos = 0,
             .file_id = 0,
             .bytes_written = 0,
-            .keydir = ccask_keydir_new(ccask_config_kdsize(cfg)),
+            .keydir = ccask_keydir_new(ccask_config_kdsize(cfg), ccask_config_kdmax(cfg)),
             .file = 0,
             .dir = 0,
             .files = { 0 },

--- a/src/ccask_db.h
+++ b/src/ccask_db.h
@@ -12,7 +12,7 @@
 #define CCASK_MAGIC_NUMBER 0x0CCA2CFF
 
 // if we are compiling tests, we want to have a small max-file-size for easier testing
-// #define MAX_FILE_BYTES 1024
+//#define MAX_FILE_BYTES 1024
 #define MAX_FILE_BYTES 512*(1024)*(1024) // 512 MB
 
 

--- a/src/ccask_keydir.h
+++ b/src/ccask_keydir.h
@@ -29,8 +29,8 @@ void ccask_kdrow_print(ccask_kdrow* kdr);
 typedef struct ccask_keydir ccask_keydir;
 
 // ccask_keydir init / delete
-ccask_keydir* ccask_keydir_init(ccask_keydir* kd, size_t size);
-ccask_keydir* ccask_keydir_new(size_t size);
+ccask_keydir* ccask_keydir_init(ccask_keydir* kd, size_t size, size_t max_size);
+ccask_keydir* ccask_keydir_new(size_t size, size_t max_size);
 void ccask_keydir_destroy(ccask_keydir* kd);
 void ccask_keydir_delete(ccask_keydir* kd);
 

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -66,7 +66,7 @@ void test_keydir(void) {
     size_t kdsz = 64;
 
     puts("keydir non-null after ccask_keydir_new");
-    kd = ccask_keydir_new(kdsz);
+    kd = ccask_keydir_new(kdsz, kdsz*2);
     assert(kd != 0);
 
     puts("keydir non-null after insert");
@@ -94,7 +94,7 @@ void test_keydir(void) {
     ccask_keydir_delete(kd);
 
     puts("with keydir size 1 (i.e. all vals mapped to same key hash) we can still discriminate btwn keys");
-    kd = ccask_keydir_new(1);
+    kd = ccask_keydir_new(1, 1);
     assert(kd != 0);
 
     uint8_t key2[5] = { 0, 0, 1, 0, 0 };


### PR DESCRIPTION
1) have a configurable min and max size
2) measure the load on the hashmap
3) when doing an insert, check if the load will be greater than a threshold value
  a) if below the threshold, just do the insert
  b) if above the threshold, resize the hashmap, rehash the existing entries, then do the insert